### PR TITLE
changing ending text in await tutorial

### DIFF
--- a/doc/tutorial/await.html
+++ b/doc/tutorial/await.html
@@ -332,8 +332,7 @@ You can even <code>await</code> inside a `Task.after` call :</p>
 	waitall()
 	
 	</code></div>
-		<p class="mt-4">Well this first tutorial on concurrent programming with Lua<sup>rt</sup> comes to its end. You have learned the basics to create and start a new Task, to bring execution flow to other Tasks, and to wait on them.</p><br><p>
-		The next part of the concurrent programming tutorial will cover the famous <code>async/await</code> functions.</p>
+		<p class="mt-4">Well this tutorial on concurrent programming with Luart comes to its end. You have learned the basics of famous <code>async/await</code> functions.</p>
 			</div>
 		  </div>
 		</div>


### PR DESCRIPTION
Ending is the same as in previous chapter (https://luart.org/doc/tutorial/async.html).